### PR TITLE
Adding SparkRDBI reference

### DIFF
--- a/docs/all.json
+++ b/docs/all.json
@@ -337,5 +337,16 @@
     "license": "Apache License 2.0 | file LICENSE",
     "url": ["https://spark.rstudio.com/"],
     "bugs": "https://github.com/sparklyr/sparklyr/issues"
+  },
+  {
+    "name": "SparkRDBI",
+    "version": "0.0.1",
+    "title": "Unofficial BDI back-end for the official SparkR R Interface to Apache Spark",
+    "description": "SparkR is the official R interface for Apache Spark big data distribution computing framework. This package provide a DBI interface for SparkR.",
+    "date": "2022-10-24",
+    "maintainer": "Ali Bellamine <contact@alibellamine.me>",
+    "license": "MIT | file LICENSE",
+    "url": ["https://github.com/alibell/SparkR-DBI/"],
+    "bugs": "https://github.com/alibell/SparkR-DBI/issues"
   }
 ]


### PR DESCRIPTION
Proposition: adding reference to SparkRDBI, an unofficial DBI back end for the SparkR library.
Related issue: https://github.com/r-dbi/backends/issues/76