### PR TITLE
Update CI workflow to Ubuntu 24.04 and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -3,8 +3,11 @@ on:
     branches:
       - main
       - master
+    paths:
+      - '.github/workflows/sync.yaml'
   schedule:
     - cron:  '0 8 * * *'
+  workflow_dispatch:
 
 name: sync
 

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -13,12 +13,12 @@ name: sync
 
 jobs:
   sync:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     name: sync
 
     env:
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -61,7 +61,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "24.04"))')
 
       - name: Install package and dependencies
         run: |


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow to use Ubuntu 24.04 (Noble) instead of Ubuntu 20.04 (Focal), and adds Dependabot configuration for automated GitHub Actions updates.

## Key Changes
- **Workflow runner**: Updated `runs-on` from `ubuntu-20.04` to `ubuntu-24.04`
- **R package manager**: Updated RSPM URL from focal to noble repository
- **System requirements**: Updated R system requirements check from Ubuntu 20.04 to 24.04
- **Workflow triggers**: Added `workflow_dispatch` for manual trigger capability
- **Path filtering**: Added path filter to only run on changes to the sync workflow file itself
- **Dependabot**: Added `.github/dependabot.yml` configuration to enable weekly automated updates for GitHub Actions

## Implementation Details
The Ubuntu version upgrade ensures the workflow runs on a more current and supported OS version. The RSPM URL change points to the appropriate package repository for Ubuntu 24.04 (Noble Numbat). The system requirements command now correctly queries dependencies for the new Ubuntu version to ensure proper package installation.

https://claude.ai/code/session_01ShBCiEq4XSLHRJGjL4L8DX